### PR TITLE
Fix Enzyme integration

### DIFF
--- a/config/jest/enzymeAdapter.js
+++ b/config/jest/enzymeAdapter.js
@@ -1,4 +1,4 @@
-import { configure } from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
+const { configure } = require('enzyme')
+const Adapter = require('enzyme-adapter-react-16')
 
 configure({ adapter: new Adapter() });

--- a/config/jest/svgTransform.js
+++ b/config/jest/svgTransform.js
@@ -1,0 +1,23 @@
+// @remove-on-eject-begin
+/**
+ * Copyright (c) 2014-present, Facebook, Inc.
+ * Copyright (c) 2018-present, Pagar.me Pagamentos, S/A.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+// @remove-on-eject-end
+'use strict';
+
+// This is a custom Jest transformer turning SVG imports into empty SVG tags.
+// http://facebook.github.io/jest/docs/en/webpack.html
+
+module.exports = {
+  process() {
+    return 'module.exports = "svg"';
+  },
+  getCacheKey() {
+    // The output is always the same.
+    return 'svgTransform';
+  },
+};

--- a/scripts/utils/createJestConfig.js
+++ b/scripts/utils/createJestConfig.js
@@ -38,7 +38,8 @@ module.exports = (resolve, rootDir, isEjecting) => {
         ? 'babel-jest'
         : resolve('config/jest/babelTransform.js'),
       '^.+\\.css$': resolve('config/jest/cssTransform.js'),
-      '^(?!.*\\.(js|jsx|mjs|css|json)$)': resolve(
+      '^.+\\.svg': resolve('config/jest/svgTransform.js'),
+      '^(?!.*\\.(js|jsx|mjs|css|json|svg)$)': resolve(
         'config/jest/fileTransform.js'
       ),
     },


### PR DESCRIPTION
This fixes two issues we had with enzyme configuration. The first was
that we were using ES6 in adapter initialization file, which is
forbidden. The second was an issue with inline SVGs being transformed
by `fileTransform`.