### PR TITLE
chore: update eslint-config-pagarme-react 1.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "request": "2.83.0",
     "style-loader": "0.19.0",
     "stylelint": "8.4.0",
-    "stylelint-config-pagarme-react": "^1.2.0",
+    "stylelint-config-pagarme-react": "1.2.0",
     "svgr": "1.6.0",
     "sw-precache-webpack-plugin": "0.11.4",
     "url-loader": "0.6.2",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "enzyme": "3.3.0",
     "enzyme-adapter-react-16": "1.1.1",
     "eslint": "4.10.0",
-    "eslint-config-pagarme-react": "^1.2.0",
+    "eslint-config-pagarme-react": "1.4.0",
     "eslint-loader": "1.9.0",
     "eslint-plugin-flowtype": "2.39.1",
     "eslint-plugin-import": "2.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2412,7 +2412,7 @@ eslint-config-airbnb@16.1.0:
   dependencies:
     eslint-config-airbnb-base "^12.1.0"
 
-eslint-config-pagarme-react@^1.2.0:
+eslint-config-pagarme-react@1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/eslint-config-pagarme-react/-/eslint-config-pagarme-react-1.4.0.tgz#0803d8066600e2201a7065342aa6e26975a41865"
   dependencies:


### PR DESCRIPTION
This PR:
- bump `eslint-config-pagarme-react` to version `1.4.0` and remove the `^` char to use only the version described in `package.json`
- remove the `^` char in `stylelint-config-pagarme-react` dependecy to use only the version described in `package.json`

## How to test
1. checkout this PR branch 
2. In a project that use `react-scripts-former-kit-dashboard`  as dependecy (eg: pilot) change  the `react-scripts-former-kit-dashboard` dependency to your local repo clone:
```
"react-scripts-former-kit-dashboard": "file:/path/to/local/clone/react-scripts-former-kit-dashboard",
```

3. delete `yarn.lock` file
4. run `yarn install`
5. look in the new `yarn.lock` if  `eslint-config-pagarme-react` version is `version "1.4.0"`
