### PR TITLE
react-modal: add folder to cssModulesIgnores

### DIFF
--- a/config/cssModulesIgnores.js
+++ b/config/cssModulesIgnores.js
@@ -3,4 +3,5 @@
 // pipeline CSS modules files are processed, but with `modules: false`.
 module.exports = [
   /.*react-dates.*\.css/,
+  /.*react-modal.*\.css/,
 ];


### PR DESCRIPTION
## Content
Add `react-modal` to cssModulesIgnores. This way, css modules ignore react-modal folder to compilation process. Related to https://github.com/pagarme/pilot/pull/1014.

