### PR TITLE
Remove ModuleScopePlugin

### DIFF
--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -14,7 +14,6 @@ const CaseSensitivePathsPlugin = require('case-sensitive-paths-webpack-plugin')
 const InterpolateHtmlPlugin = require('react-dev-utils/InterpolateHtmlPlugin')
 const WatchMissingNodeModulesPlugin = require('react-dev-utils/WatchMissingNodeModulesPlugin')
 const eslintFormatter = require('react-dev-utils/eslintFormatter')
-const ModuleScopePlugin = require('react-dev-utils/ModuleScopePlugin')
 const getCSSModuleLocalIdent = require('react-dev-utils/getCSSModuleLocalIdent')
 const getClientEnvironment = require('./env')
 const paths = require('./paths')
@@ -145,14 +144,6 @@ module.exports = {
       // https://www.smashingmagazine.com/2016/08/a-glimpse-into-the-future-with-react-native-for-web/
       'react-native': 'react-native-web',
     },
-    plugins: [
-      // Prevents users from importing files from outside of src/ (or node_modules/).
-      // This often causes confusion because we only process files within src/ with babel.
-      // To fix this, we prevent you from importing files out of src/ -- if you'd like to,
-      // please link the files into your node_modules/ and let module-resolution kick in.
-      // Make sure your source files are compiled, as they will not be processed in any way.
-      new ModuleScopePlugin(paths.appSrc, [paths.appPackageJson]),
-    ],
   },
   module: {
     strictExportPresence: true,
@@ -171,10 +162,6 @@ module.exports = {
           baseConfig: {
             extends: [require.resolve('eslint-config-pagarme-react')],
           },
-          // @remove-on-eject-begin
-          ignore: false,
-          useEslintrc: false,
-          // @remove-on-eject-end
         },
         include: paths.srcPaths,
       },

--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -17,8 +17,6 @@ const OptimizeCSSAssetsPlugin = require('optimize-css-assets-webpack-plugin')
 const ManifestPlugin = require('webpack-manifest-plugin')
 const InterpolateHtmlPlugin = require('react-dev-utils/InterpolateHtmlPlugin')
 const SWPrecacheWebpackPlugin = require('sw-precache-webpack-plugin')
-const eslintFormatter = require('react-dev-utils/eslintFormatter')
-const ModuleScopePlugin = require('react-dev-utils/ModuleScopePlugin')
 const getCSSModuleLocalIdent = require('react-dev-utils/getCSSModuleLocalIdent')
 const paths = require('./paths')
 const getClientEnvironment = require('./env')
@@ -209,14 +207,6 @@ module.exports = {
       // https://www.smashingmagazine.com/2016/08/a-glimpse-into-the-future-with-react-native-for-web/
       'react-native': 'react-native-web',
     },
-    plugins: [
-      // Prevents users from importing files from outside of src/ (or node_modules/).
-      // This often causes confusion because we only process files within src/ with babel.
-      // To fix this, we prevent you from importing files out of src/ -- if you'd like to,
-      // please link the files into your node_modules/ and let module-resolution kick in.
-      // Make sure your source files are compiled, as they will not be processed in any way.
-      new ModuleScopePlugin(paths.appSrc, [paths.appPackageJson]),
-    ],
   },
   module: {
     strictExportPresence: true,


### PR DESCRIPTION
This PR aims to fix a problem in the development build which was creating conflicts in a `yarn workspace`  environment.
The props `useEslint` was removed and also the `eslintFormatter`  was removed from production build where it wasn't been used.

## Context
- Fix development `webpack` configuration

## How to test

1. Clone this project
```
git clone -b update/dependencies git@github.com:pagarme/react-scripts-former-kit-dashboard.git
```
2. Go to the project folder
```
  cd react-scripts-former-kit-dashboard/
```
3. Build a pack using the npm pack command
```
npm pack
```
4. In [Pilot project] change the `package.json` refence to `react-scripts-former-kit-dashboard` to the path for the created pack. 
![screen shot 2019-01-16 at 20 00 45](https://user-images.githubusercontent.com/1773766/51281404-71360f80-19c9-11e9-9ea7-5ab20ea21400.png)

5. In [Pilot project]  folder remove the `node_modules` and reinstall everything
```
  rm -rf node_modules/
  yarn
```
6.  Create a link in the  [`former-kit-skin-pagarme`](https://github.com/pagarme/former-kit-skin-pagarme) project folder with the command `yarn link`

7.  Create a link with the one created in the previous step using the command `yarn link former-kit-skin-pagarme`

8. Run `yarn start`, in the [Pilot project](https://github.com/pagarme/pilot) using the branch `update/react-scripts`( which have all lint problems fixed )  and the project must work correctly.

Solves https://github.com/pagarme/pilot/issues/1144