### PR TITLE
Refactor add react to resolve alias

### DIFF
--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -143,6 +143,8 @@ module.exports = {
       // Support React Native Web
       // https://www.smashingmagazine.com/2016/08/a-glimpse-into-the-future-with-react-native-for-web/
       'react-native': 'react-native-web',
+      // resolves react references to avoid hooks multiple react error
+      'react': path.dirname(require.resolve('react'))
     },
   },
   module: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-scripts-former-kit-dashboard",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Configuration and scripts for Create React App.",
   "repository": "pagarme/react-scripts-former-kit-dashboard",
   "license": "MIT",


### PR DESCRIPTION
This PR adds `react` to a list of aliases which is used by `webpack` to reference a specific folder/path for these listed dependencies. When these dependencies are called in the code with `import` or `require` they will be redirected to the aliases paths/folders.

## Linked issues
- [x] Resolves https://github.com/pagarme/pilot/issues/1267

## How to test
TLDR: create an npm pack for this project and reference it in the Pilot project package.json and also link the `former-kit` project to pilot using `yarn link`. After that run the Pilot and go to the transactions list.

1. Clone this project
```
git clone -b update/dependencies git@github.com:pagarme/react-scripts-former-kit-dashboard.git
```
2. Go to the project folder
```
  cd react-scripts-former-kit-dashboard/
```
3. Change to this branch
```
  git checkout refactor/add-react-alias
```
4. Build a pack using the npm pack command this command will create a `.tgz` pack like `react-scripts-former-kit-dashboard-2.0.2.tgz`
```
npm pack
```
5. In the [Pilot](https://github.com/pagarme/pilot/) project you should change the `react-scripts-former-kit-dashboard ` reference in `package.json` dependency to the absolute path from the pack created in the previous step, your `package.json` should look like this:
```json
...
    "react-redux": "6.0.0",
    "react-router-dom": "4.3.1",
    "react-scripts-former-kit-dashboard": "/your_absolute_path/react-scripts-former-kit-dashboard/react-scripts-former-kit-dashboard-2.0.2.tgz",
    "react-textfit": "1.1.0",
    "react-vanilla-form": "0.6.1",
...
```
6. You will also need to link Pilot with  Former-kit
  6.1 Create a link in Former-kit
```
yarn link
```
  6.2 Link Former-kit in Pilot
```
yarn link former-kit
```
7 At Pilot run the start script
```
yarn start
```
8 Check if the page `Transactions` is working in the started server