### PR TITLE
Add sync import support

### DIFF
--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -217,6 +217,7 @@ module.exports = {
               // @remove-on-eject-end
               presets: [require.resolve('babel-preset-react-app')],
               plugins: [
+                require.resolve('@babel/plugin-syntax-dynamic-import'),
                 [
                   require.resolve('babel-plugin-named-asset-import'),
                   {

--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -279,6 +279,7 @@ module.exports = {
                   { helpers: false },
                 ],
               ],
+              plugins: [require.resolve('@babel/plugin-syntax-dynamic-import')],
               sourceMaps: false,
             },
           },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-scripts-former-kit-dashboard",
-  "version": "2.0.3",
+  "version": "2.1.0",
   "description": "Configuration and scripts for Create React App.",
   "repository": "pagarme/react-scripts-former-kit-dashboard",
   "license": "MIT",
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "@babel/core": "7.5.5",
+    "@babel/plugin-syntax-dynamic-import": "7.2.0",
     "@babel/plugin-transform-react-constant-elements": "7.5.0",
     "@babel/preset-env": "7.5.5",
     "@babel/preset-react": "7.0.0",
@@ -55,7 +56,7 @@
     "html-webpack-plugin": "4.0.0-beta.8",
     "identity-obj-proxy": "3.0.0",
     "jest": "24.8.0",
-    "jest-canvas-mock":"2.1.0",
+    "jest-canvas-mock": "2.1.0",
     "loader-utils": "1.2.3",
     "mini-css-extract-plugin": "0.8.0",
     "object-assign": "4.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4011,16 +4011,16 @@ eslint-scope@^5.0.0:
     estraverse "^4.1.1"
 
 eslint-utils@^1.3.1:
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-1.4.0.tgz#e2c3c8dba768425f897cf0f9e51fe2e241485d4c"
-  integrity sha512-7ehnzPaP5IIEh1r1tkjuIrxqhNkzUJa9z3R92tLJdZIVdWaczEhr3EbhGtsMrVxi1KeR8qA7Off6SWc5WNQqyQ==
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-1.4.2.tgz#166a5180ef6ab7eb462f162fd0e6f2463d7309ab"
+  integrity sha512-eAZS2sEUMlIeCjBeubdj45dmBHQwPHWyBcT1VSYB7o9x9WRRqKxyUoiXlRjyAwzN7YEzHJlYg0NmzDRWx6GP4Q==
   dependencies:
     eslint-visitor-keys "^1.0.0"
 
 eslint-visitor-keys@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#3f3180fb2e291017716acb4c9d6d5b5c34a6a81d"
-  integrity sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz#e2a82cea84ff246ad6fb57f9bde5b46621459ec2"
+  integrity sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==
 
 eslint@6.1.0:
   version "6.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -373,7 +373,7 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
-"@babel/plugin-syntax-dynamic-import@^7.2.0":
+"@babel/plugin-syntax-dynamic-import@7.2.0", "@babel/plugin-syntax-dynamic-import@^7.2.0":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.2.0.tgz#69c159ffaf4998122161ad8ebc5e6d1f55df8612"
   integrity sha512-mVxuJ0YroI/h/tbFTPGZR8cv6ai+STMKNBq0f8hFxsxWjl94qqhsb+wXbpNMDPU3cfR1TIsVFzU3nXyZMqyK4w==


### PR DESCRIPTION
This pull request adds support to use import async. It is necessary to implement a better chunk policy

now is possible to use:
```js
const Login = lazy(() => import('./Login'))
```
#### how to test
1. checkout branch `add/import-async`
2. run yarn to install new dependencies
3. create a pack `npm pack`
4. copy the path to the pack created
5. go to the Pilot project directory
6. checkout branch `add/import-async`
7. edit `/packages/pilot/package.json` to add your generate pack (item 4) as `react-scripts-former-kit-dashboard` dependency
https://github.com/pagarme/pilot/blob/d8235feba30e424f1ee2fda38d7ef0b3a233b320/packages/pilot/package.json#L33
8. run `yarn` in pilot project
9. validating development evironment
  - run `yarn start` inside `packages/pilot`
  - access  http://localhost:3000/
  - the application needs to load correctly
 - navigate to `localhost:3000/#/account/signup` and verify if  a chunk is downloaded
10. validating production evironment
  - run `yarn build` inside `packages/pilot`
  - run `npx serve -s build`
  - access  http://localhost:5000/
  - the application needs to load correctly
  - navigate to `localhost:5000/#/account/signup` and verify if  a chunk is downloaded


related https://github.com/pagarme/pilot/issues/1401