### PR TITLE
Code splitting - Update mini-css-extract-plugin config

### DIFF
--- a/config/webpack.config.dev.js
+++ b/config/webpack.config.dev.js
@@ -95,7 +95,7 @@ module.exports = {
     // containing code from all our entry points, and the Webpack runtime.
     filename: 'static/js/bundle.js',
     // There are also additional JS chunk files if you use code splitting.
-    chunkFilename: 'static/js/[name].chunk.js',
+    chunkFilename: 'static/js/[name].[chunkhash:8].chunk.js',
     // This is the URL that app is served from. We use "/" in development.
     publicPath: publicPath,
     // Point sourcemap entries to original disk location (format as URL on Windows)

--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -393,6 +393,7 @@ module.exports = {
       // both options are optional
       filename: 'static/css/[name].[contenthash:8].css',
       chunkFilename: 'static/css/[name].[contenthash:8].chunk.css',
+      ignoreOrder: true,
     }),
     // Generate a manifest file which contains a mapping of all asset filenames
     // to their corresponding output file so that tools can pick it up without


### PR DESCRIPTION
This pull request sets the `ignoreOrder` option of `mini-css-extract-plugin` to `true`. Because now that we are using different chunks of files, a warning was getting reported on our `build` process, which then causes our CI task to fail.

The warning:
![image](https://user-images.githubusercontent.com/18339615/67015527-0be48b80-f0cd-11e9-91c9-51bcdab79e58.png)

More info about this option can be found on: https://github.com/webpack-contrib/mini-css-extract-plugin#remove-order-warnings

Contributes to resolving https://github.com/pagarme/pilot/issues/1401
 